### PR TITLE
Make the example client use the default URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ from datetime import datetime, timedelta
 
 API_KEY = decouple.config("API_KEY")
 BASE_URL = decouple.config("LEAKIX_HOST", default=None)
-CLIENT = Client(api_key=API_KEY, base_url=BASE_URL)
+CLIENT = Client(api_key=API_KEY)
 
 
 def example_get_host_filter_plugin():

--- a/example/example_client.py
+++ b/example/example_client.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 
 API_KEY = decouple.config("API_KEY")
 BASE_URL = decouple.config("LEAKIX_HOST", default=None)
-CLIENT = Client(api_key=API_KEY, base_url=BASE_URL)
+CLIENT = Client(api_key=API_KEY)
 
 
 def example_get_host_filter_plugin():

--- a/example/example_client.py
+++ b/example/example_client.py
@@ -23,7 +23,7 @@ def example_get_service_filter_plugin():
     """
     query_http_ntlm = MustQuery(field=PluginField(Plugin.HttpNTLM))
     response = CLIENT.get_service(queries=[query_http_ntlm])
-    assert response.status_code() == 200
+    assert response.status_code() == 200,response.status_code()
     # check we only get NTML related services
     assert all((i.tags == ["ntlm"] for i in response.json()))
 
@@ -45,7 +45,7 @@ def example_get_leaks_filter_multiple_plugins():
     query_http_ntlm = MustQuery(field=PluginField(Plugin.HttpNTLM))
     query_country = MustQuery(field=CountryField("France"))
     response = CLIENT.get_leak(queries=[query_http_ntlm, query_country])
-    assert response.status_code() == 200
+    assert response.status_code() == 200, response.status_code()
     assert all(
         (
             i.geoip.country_name == "France" and i.tags == ["ntlm"]
@@ -58,7 +58,7 @@ def example_get_leaks_multiple_filter_plugins_must_not():
     query_http_ntlm = MustQuery(field=PluginField(Plugin.HttpNTLM))
     query_country = MustNotQuery(field=CountryField("France"))
     response = CLIENT.get_leak(queries=[query_http_ntlm, query_country])
-    assert response.status_code() == 200
+    assert response.status_code() == 200, response.status_code()
     assert all(
         (
             i.geoip.country_name != "France" and i.tags == ["ntlm"]
@@ -71,7 +71,7 @@ def example_get_leak_raw_query():
     raw_query = '+plugin:HttpNTLM +country:"France"'
     query = RawQuery(raw_query)
     response = CLIENT.get_leak(queries=[query])
-    assert response.status_code() == 200
+    assert response.status_code() == 200, response.status_code()
     assert all(
         (
             i.geoip.country_name == "France" and i.tags == ["ntlm"]

--- a/leakix/client.py
+++ b/leakix/client.py
@@ -25,16 +25,17 @@ class HostResult(Model):
     Leaks: fields.Optional(fields.List(fields.Nested(l9format.L9Event)))
 
 
+DEFAULT_URL = "https://leakix.net"
 class Client:
     MAX_RESULTS_PER_PAGE = 20
 
     def __init__(
         self,
         api_key: Optional[str] = None,
-        base_url: Optional[str] = "https://leakix.net",
+        base_url: Optional[str] = DEFAULT_URL,
     ):
         self.api_key = api_key
-        self.base_url = base_url
+        self.base_url = base_url if base_url else DEFAULT_URL
         self.headers = {
             "Accept": "application/json",
             "User-agent": "leakix-client-python/%s" % __VERSION__,


### PR DESCRIPTION
This makes the example client arguably a bit easier to use.