### PR TITLE
Adding auto build and publish in pipy

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,37 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,47 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+    - '*'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        ls -la
+        pwd
+        ls -R
+        pip install build
+    - name: Build package
+      run: |
+        ls -la
+        python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.api_de_pip }}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+from setuptools import setup
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+    
+
+setup(
+    name='leakix',
+    version='0.1.10',
+    description='This lib add support to use the API from leakix.net',
+    license='MIT',
+    keywords=['python, package, distribution'],
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author='Danny Willems',
+    url='https://github.com/LeakIX/LeakIXClient-Python',
+    packages=['leakix'],
+    scripts=['executable/cli.py'],
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
+    python_requires='>=3.6'
+)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
-    
 
 setup(
     name='leakix',


### PR DESCRIPTION
Hi Danny, this is what i use to build and publish the packager to pipy, you just need to add the api token from pipy to a Repository secrets in Settings -> Secrets and Variables -> Actions.

I use it in python-publis.yml in .github/workflows  -> password: ${{ secrets.api_de_pip }}
 
And then: every time you push to main the python packages is built and every time you tag in github it automatically publish in pipy 

Let me konw if it helps.

Note: When you are going to tag you need to update version in setup.py also to keep sync the pipy documentation.