### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 Official LeakIX python client
 
 ## Install
+### Using pipx, pipenvn or virtualenv is recommended.
 
 ```
-pip install leakix
+pipx install leakix
 ```
 
 To run tests, use `poetry run pytest`.


### PR DESCRIPTION
pipx creates isolated environments. it prevent conflicts between dependencies 
Those virtual environments are installed under a fixed location, ~/.local/share/pipx/venvs/<package>, and the Python applications installed have symlinks added to the ~/.local/bin.

pipx install leakix



   ` Creates a virtual environment via the Python module venv at ~/.local/share/pipx/venvs/leakix`

`
Since pipx ensurepath has already added the location "~/.local/bin" to your PATH, the command leakix
-atmos 