### PR TITLE
CI: add Python 3.13 support

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,13 +6,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         poetry-version: ["1.4.0"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install poetry


### PR DESCRIPTION
## Summary
- Add Python 3.13 to CI test matrix
- Update actions/checkout from v2 to v4
- Update actions/setup-python from v2 to v5

## Test plan
- [ ] Verify CI passes on all Python versions (3.7-3.13)
- [ ] Verify CI passes on all platforms (ubuntu, macos, windows)