### PR TITLE
CI: add pip-audit security scanning

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,8 +6,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        poetry-version: ["1.4.0"]
+        python-version: ["3.13"]
+        poetry-version: ["2.3.1"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -26,5 +26,4 @@ jobs:
       - name: Run black
         run: poetry run black leakix/*.py tests/*.py example/*.py --check
       - name: Security audit
-        if: matrix.python-version != '3.7'
         run: poetry run pip-audit

--- a/example/example_client.py
+++ b/example/example_client.py
@@ -5,7 +5,6 @@ from leakix.field import PluginField, CountryField, TimeField, Operator
 from leakix.plugin import Plugin
 from datetime import datetime, timedelta
 
-
 API_KEY = decouple.config("API_KEY")
 CLIENT = Client(api_key=API_KEY)
 

--- a/leakix/client.py
+++ b/leakix/client.py
@@ -11,7 +11,6 @@ from leakix.plugin import APIResult
 from leakix.field import *
 from leakix.domain import L9Subdomain
 
-
 __VERSION__ = "0.1.9"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,12 @@ description = "Official python client for LeakIX (https://leakix.net)"
 authors = ["Danny Willems <danny@leakix.net>"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.13"
 requests = "*"
 l9format = "=1.3.1a3"
 fire = "^0.5.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 python-decouple = "*"
 pytest = "*"
 black = "*"


### PR DESCRIPTION
## Summary
- Add `pip-audit` to dev dependencies for security vulnerability scanning
- Add security audit step to CI workflow
- Require Python 3.13+ (drop support for older versions)
- Update Poetry from 1.4.0 to 2.3.1
- Fix deprecated `[tool.poetry.dev-dependencies]` → `[tool.poetry.group.dev.dependencies]`
- Update actions/checkout from v2 to v4
- Update actions/setup-python from v2 to v5
- Fix black formatting issues

## Test plan
- [ ] Verify CI passes on all platforms (ubuntu, macos, windows)
- [ ] Verify pip-audit runs successfully