### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-03-20
+
 ### Added
 
 - Add `get_plugin(name)` method to fetch plugin description by name
@@ -99,7 +101,8 @@ and this project adheres to
 - Query building with MustQuery, MustNotQuery, ShouldQuery
 - Field filters: TimeField, PluginField, IPField, PortField, CountryField
 
-[unreleased]: https://github.com/LeakIX/LeakIXClient-Python/compare/v1.0.0...HEAD
+[unreleased]: https://github.com/LeakIX/LeakIXClient-Python/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/LeakIX/LeakIXClient-Python/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/LeakIX/LeakIXClient-Python/compare/v0.1.10...v1.0.0
 [0.1.10]: https://github.com/LeakIX/LeakIXClient-Python/compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com/LeakIX/LeakIXClient-Python/releases/tag/v0.1.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "leakix"
-version = "1.0.0"
+version = "1.1.0"
 description = "Official python client for LeakIX (https://leakix.net)"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- Bump version to 1.1.0
- Move unreleased changelog entries under 1.1.0 section

### What's new in 1.1.0
- `get_plugin(name)` method to fetch a single plugin description by name (#85)
- README badge and Python version updates (#84)
- CI PR hygiene checks (#81)

## Test plan
- [x] All tests pass
- [x] Lint, typecheck, format checks pass
- [x] After merge, tag v1.1.0 and publish to PyPI